### PR TITLE
Change laravel package name to mitchellvanw/laravel-doctrine

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After This you'll need to add the facade. Open your `app/config/app.php` configu
 It's recommended to publish the package configuration.
 
 ```php
-php artisan config:publish mitchell/laravel-doctrine --path=vendor/mitchellvanw/laravel-doctrine/config
+php artisan config:publish mitch/laravel-doctrine --path=vendor/mitchellvanw/laravel-doctrine/config
 ```
 
 ## 2 Minutes


### PR DESCRIPTION
The service provider defines the package name as `mitch/laravel-doctrine`, this updates the example command to use the correct package name.
