### PR TITLE
Changes --sql option type to VALUE_NONE

### DIFF
--- a/src/Console/SchemaCreateCommand.php
+++ b/src/Console/SchemaCreateCommand.php
@@ -64,7 +64,7 @@ class SchemaCreateCommand extends Command
     protected function getOptions()
     {
         return [
-            ['sql', null, InputOption::VALUE_OPTIONAL, 'Dumps SQL query and does not execute creation.']
+            ['sql', false, InputOption::VALUE_NONE, 'Dumps SQL query and does not execute creation.']
         ];
     }
 } 

--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -68,7 +68,7 @@ class SchemaDropCommand extends Command
     protected function getOptions()
     {
         return [
-            ['sql', null, InputOption::VALUE_OPTIONAL, 'Dumps SQL query and does not execute drop.'],
+            ['sql', false, InputOption::VALUE_NONE, 'Dumps SQL query and does not execute drop.'],
         ];
     }
 }

--- a/src/Console/SchemaUpdateCommand.php
+++ b/src/Console/SchemaUpdateCommand.php
@@ -70,7 +70,7 @@ class SchemaUpdateCommand extends Command
     protected function getOptions()
     {
         return [
-            ['sql', null, InputOption::VALUE_OPTIONAL, 'Dumps SQL query and does not execute update.'],
+            ['sql', false, InputOption::VALUE_NONE, 'Dumps SQL query and does not execute update.'],
             ['clean', null, InputOption::VALUE_OPTIONAL, 'When using clean model all non-relevant to this metadata assets will be cleared.']
         ];
     }


### PR DESCRIPTION
When the option is used simply as a switch the type should be `VALUE_NONE`. 
