### PR TITLE
Lazy Load Doctrine's SchemaTool

### DIFF
--- a/src/Console/SchemaCommand.php
+++ b/src/Console/SchemaCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mitch\LaravelDoctrine\Console;
+
+use Illuminate\Console\Command;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+
+abstract class SchemaCommand extends Command
+{
+    /**
+     * Schema tool
+     *
+     * @var \Doctrine\ORM\Tools\SchemaTool
+     */
+    private $tool;
+
+    /**
+     * The class metadata factory
+     *
+     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
+     */
+    protected $metadata;
+
+    public function __construct(ClassMetadataFactory $metadata)
+    {
+        parent::__construct();
+
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Lazy loading of SchemaTool.
+     *
+     * @return \Doctrine\ORM\Tools\SchemaTool
+     */
+    protected function getTool()
+    {
+        if (is_null($this->tool)) {
+            $this->tool = $this->getLaravel()->make('Doctrine\ORM\Tools\SchemaTool');
+        }
+
+        return $this->tool;
+    }
+} 

--- a/src/Console/SchemaCreateCommand.php
+++ b/src/Console/SchemaCreateCommand.php
@@ -1,11 +1,8 @@
 <?php namespace Mitch\LaravelDoctrine\Console;
 
-use Illuminate\Console\Command;
-use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Symfony\Component\Console\Input\InputOption;
 
-class SchemaCreateCommand extends Command
+class SchemaCreateCommand extends SchemaCommand
 {
     /**
      * The console command name.
@@ -22,28 +19,6 @@ class SchemaCreateCommand extends Command
     protected $description = 'Create database schema from models';
 
     /**
-     * The schema tool.
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $tool;
-
-    /**
-     * The class metadata factory
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $metadata;
-
-    public function __construct(SchemaTool $tool, ClassMetadataFactory $metadata)
-    {
-        parent::__construct();
-
-        $this->tool = $tool;
-        $this->metadata = $metadata;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
@@ -52,11 +27,11 @@ class SchemaCreateCommand extends Command
     {
         if ($this->option('sql')) {
             $this->info('Outputting create query:');
-            $sql = $this->tool->getCreateSchemaSql($this->metadata->getAllMetadata());
+            $sql = $this->getTool()->getCreateSchemaSql($this->metadata->getAllMetadata());
             $this->info(implode(';' . PHP_EOL, $sql));
         } else {
             $this->info('Creating database schema...');
-            $this->tool->createSchema($this->metadata->getAllMetadata());
+            $this->getTool()->createSchema($this->metadata->getAllMetadata());
             $this->info('Schema has been created!');
         }
     }

--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -1,11 +1,8 @@
 <?php namespace Mitch\LaravelDoctrine\Console; 
 
-use Illuminate\Console\Command;
-use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Symfony\Component\Console\Input\InputOption;
 
-class SchemaDropCommand extends Command
+class SchemaDropCommand extends SchemaCommand
 {
     /**
      * The console command name.
@@ -22,35 +19,13 @@ class SchemaDropCommand extends Command
     protected $description = 'Drop database schema';
 
     /**
-     * The schema tool.
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $tool;
-
-    /**
-     * The class metadata factory
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $metadata;
-
-    public function __construct(SchemaTool $tool, ClassMetadataFactory $metadata)
-    {
-        parent::__construct();
-
-        $this->tool = $tool;
-        $this->metadata = $metadata;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
      */
     public function fire()
     {
-        $sql = $this->tool->getDropSchemaSQL($this->metadata->getAllMetadata());
+        $sql = $this->getTool()->getDropSchemaSQL($this->metadata->getAllMetadata());
         if (empty($sql)) {
             $this->info('Current models do not exist in schema.');
             return;
@@ -60,7 +35,7 @@ class SchemaDropCommand extends Command
             $this->info(implode(';' . PHP_EOL, $sql));
         } else {
             $this->info('Dropping database schema....');
-            $this->tool->dropSchema($this->metadata->getAllMetadata());
+            $this->getTool()->dropSchema($this->metadata->getAllMetadata());
             $this->info('Schema has been dropped!');
         }
     }

--- a/src/Console/SchemaUpdateCommand.php
+++ b/src/Console/SchemaUpdateCommand.php
@@ -1,11 +1,8 @@
 <?php namespace Mitch\LaravelDoctrine\Console; 
 
-use Illuminate\Console\Command;
-use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Symfony\Component\Console\Input\InputOption;
 
-class SchemaUpdateCommand extends Command
+class SchemaUpdateCommand extends SchemaCommand
 {
     /**
      * The console command name.
@@ -22,28 +19,6 @@ class SchemaUpdateCommand extends Command
     protected $description = 'Update database schema to match models';
 
     /**
-     * The schema tool.
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $tool;
-
-    /**
-     * The class metadata factory
-     *
-     * @var \Doctrine\ORM\Tools\SchemaTool
-     */
-    private $metadata;
-
-    public function __construct(SchemaTool $tool, ClassMetadataFactory $metadata)
-    {
-        parent::__construct();
-
-        $this->tool = $tool;
-        $this->metadata = $metadata;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
@@ -52,7 +27,7 @@ class SchemaUpdateCommand extends Command
     {
         $this->info('Checking if database needs updating....');
         $clean = $this->option('clean');
-        $sql = $this->tool->getUpdateSchemaSql($this->metadata->getAllMetadata(), $clean);
+        $sql = $this->getTool()->getUpdateSchemaSql($this->metadata->getAllMetadata(), $clean);
         if (empty($sql)) {
             $this->info('No updates found.');
             return;
@@ -62,7 +37,7 @@ class SchemaUpdateCommand extends Command
             $this->info(implode(';' . PHP_EOL, $sql));
         } else {
             $this->info('Updating database schema....');
-            $this->tool->updateSchema($this->metadata->getAllMetadata());
+            $this->getTool()->updateSchema($this->metadata->getAllMetadata());
             $this->info('Schema has been updated!');
         }
     }


### PR DESCRIPTION
When running `php aritsan` or any `artisan` command all commands are initialized. The modified schema related commands all require an instance of `SchemaTool`. Since `SchemaTool` requires a correctly configured database connection, if you have an incorrectly configured instance `php artisan` will crash. This effects all artisan commands and in turn effects composer commands. The below change will lazy load the `SchemaTool` preventing `php artisan` from crashing until the commands themselves are actually executed.
