### PR TITLE
Use CURRENT_TIMESTAMP in favour of NOW() in TrashedFilter

### DIFF
--- a/src/Filters/TrashedFilter.php
+++ b/src/Filters/TrashedFilter.php
@@ -8,7 +8,7 @@ class TrashedFilter extends SQLFilter
     public function addFilterConstraint(ClassMetadata $metadata, $table)
     {
         if ($this->isSoftDeletable($metadata->rootEntityName))
-            return "{$table}.deleted_at IS NULL || NOW() < {$table}.deleted_at";
+            return "{$table}.deleted_at IS NULL || CURRENT_TIMESTAMP < {$table}.deleted_at";
 
         return '';
     }


### PR DESCRIPTION
Use of NOW() directly in TrashedFilter is MySQL specific and does not work with other database engines e.g. Oracle, SQLite etc. 

CURRENT_TIMESTAMP is a better value as it features in standard ANSI SQL and is supported by most DBMS. See:

http://stackoverflow.com/questions/20541362/db-agnostic-sql-for-current-timestamp
