### PR TITLE
Maintain laravel database path for sqlite.

### DIFF
--- a/src/Configuration/SqliteMapper.php
+++ b/src/Configuration/SqliteMapper.php
@@ -41,6 +41,6 @@ class SqliteMapper implements Mapper
 		if ($configuration['database'] == ':memory:')
 			$sqliteConfig['memory'] = true;
 		else
-			$sqliteConfig['path'] = app_path('database').'/'.$configuration['database'].'.sqlite';
+			$sqliteConfig['path'] = $configuration['database'];
 	}
-} 
+}


### PR DESCRIPTION
I tried to use laravel-doctrine with sqlite and it didn't work out of the box. I had to change the default configuration for database: "**DIR**.'/../database/production.sqlite'" to just the database name.

Then, when i tried to use artisan migrate to create the database, it was created at the root folder of the laravel instalation.

So, i think that it is better to maintain the location of the database as it is configured, and the mapper only needs to assign $configuration['database'] into 'path'.

Check it out, please.
