### PR TITLE
Fix Laravel Doctrine Service Provider

### DIFF
--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -101,7 +101,8 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             $entityManager->getFilters()->enable('trashed');
             return $entityManager;
         });
-        $this->app->singleton(EntityManagerInterface::class, EntityManager::class);
+
+        $this->app->alias(EntityManager::class, EntityManagerInterface::class);
     }
 
     private function registerClassMetadataFactory()

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -123,22 +123,7 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
         });
     }
 
-    /**
-     * Get the services provided by the provider.
-     * @return array
-     */
-    public function provides()
-    {
-        return [
-            CacheManager::class,
-            EntityManagerInterface::class,
-            EntityManager::class,
-            ClassMetadataFactory::class,
-            DriverMapper::class,
-            AuthManager::class,
-        ];
-    }
-
+   
     /**
      * Map Laravel's to Doctrine's database configuration requirements.
      * @param $config


### PR DESCRIPTION
Aliases the Doctrine\ORM\EntityManagerInterface to our service, instead bind as singleton it to Container. Remove provides methods because our service provider is not deferred service. That method is not necessary for non deferred service.