### PR TITLE
Support for custom EntityListenerResolver

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -32,5 +32,7 @@ return [
 
     'repositoryFactory' => null,
 
-    'logger' => null
+    'logger' => null,
+
+    'resolver' => null
 ];

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -91,6 +91,8 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             $metadata->setAutoGenerateProxyClasses($config['proxy']['auto_generate']);
             $metadata->setDefaultRepositoryClassName($config['repository']);
             $metadata->setSQLLogger($config['logger']);
+            if (isset($config['resolver']))
+                $metadata->setEntityListenerResolver($config['resolver']);
 
             if (isset($config['proxy']['namespace']))
                 $metadata->setProxyNamespace($config['proxy']['namespace']);


### PR DESCRIPTION
Anyone who would like to use an [EntityListener](http://doctrine-orm.readthedocs.org/en/latest/reference/events.html#entity-listeners-resolver) and inject into it's constructor using Laravel's DI, will need a custom EntityListenerResolver in which they can call \App::make with service providers for DI.

If you are on board, I think we should provide this by default aka LaravelListenerResolver that will do this automatically.
