### PR TITLE
Added Laravel naming strategy

### DIFF
--- a/src/Configuration/LaravelNamingStrategy.php
+++ b/src/Configuration/LaravelNamingStrategy.php
@@ -1,0 +1,110 @@
+<?php namespace Mitch\LaravelDoctrine\Configuration;
+
+use Illuminate\Support\Str;
+use Doctrine\ORM\Mapping\NamingStrategy;
+
+class LaravelNamingStrategy implements NamingStrategy
+{
+	/**
+	 * @type Str
+	 */
+	private $str;
+
+	public function __construct(Str $str)
+	{
+		$this->str = $str;
+	}
+
+	/**
+	 * Returns a table name for an entity class.
+	 *
+	 * @param string $className The fully-qualified class name.
+	 *
+	 * @return string A table name.
+	 */
+	public function classToTableName($className)
+	{
+		return $this->str->plural($this->classToFieldName($className));
+	}
+
+	/**
+	 * Returns a column name for a property.
+	 *
+	 * @param string      $propertyName A property name.
+	 * @param string|null $className    The fully-qualified class name.
+	 *
+	 * @return string A column name.
+	 */
+	public function propertyToColumnName($propertyName, $className = null)
+	{
+		return $this->str->snake($propertyName);
+	}
+
+	/**
+	 * Returns the default reference column name.
+	 *
+	 * @return string A column name.
+	 */
+	public function referenceColumnName()
+	{
+		return 'id';
+	}
+
+	/**
+	 * Returns a join column name for a property.
+	 *
+	 * @param string $propertyName A property name.
+	 *
+	 * @return string A join column name.
+	 */
+	public function joinColumnName($propertyName)
+	{
+		return $this->str->snake($this->str->singular($propertyName)) . '_' . $this->referenceColumnName();
+	}
+
+	/**
+	 * Returns a join table name.
+	 *
+	 * @param string      $sourceEntity The source entity.
+	 * @param string      $targetEntity The target entity.
+	 * @param string|null $propertyName A property name.
+	 *
+	 * @return string A join table name.
+	 */
+	public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
+	{
+		return $this->classToFieldName($sourceEntity) . '_' . $this->classToFieldName($targetEntity);
+	}
+
+	/**
+	 * Returns the foreign key column name for the given parameters.
+	 *
+	 * @param string      $entityName           An entity.
+	 * @param string|null $referencedColumnName A property.
+	 *
+	 * @return string A join column name.
+	 */
+	public function joinKeyColumnName($entityName, $referencedColumnName = null)
+	{
+		return $this->classToFieldName($entityName) . '_' .
+			($referencedColumnName ?: $this->referenceColumnName());
+	}
+
+	private function classToFieldName($className)
+	{
+		return $this->str->snake(class_basename($className));
+	}
+
+	/**
+	 * Returns a column name for an embedded property.
+	 *
+	 * @param string $propertyName
+	 * @param string $embeddedColumnName
+	 *
+	 * @return string
+	 */
+	function embeddedFieldToColumnName($propertyName, $embeddedColumnName, $className = null, $embeddedClassName = null)
+	{
+		return $propertyName.'_'.$embeddedColumnName;
+	}
+}

--- a/src/Configuration/LaravelNamingStrategy.php
+++ b/src/Configuration/LaravelNamingStrategy.php
@@ -73,7 +73,14 @@ class LaravelNamingStrategy implements NamingStrategy
 	 */
 	public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
 	{
-		return $this->classToFieldName($sourceEntity) . '_' . $this->classToFieldName($targetEntity);
+		$names = [
+			$this->classToFieldName($sourceEntity),
+			$this->classToFieldName($targetEntity)
+		];
+
+		sort($names);
+
+		return implode('_', $names);
 	}
 
 	/**
@@ -103,7 +110,7 @@ class LaravelNamingStrategy implements NamingStrategy
 	 *
 	 * @return string
 	 */
-	function embeddedFieldToColumnName($propertyName, $embeddedColumnName, $className = null, $embeddedClassName = null)
+	public function embeddedFieldToColumnName($propertyName, $embeddedColumnName, $className = null, $embeddedClassName = null)
 	{
 		return $propertyName.'_'.$embeddedColumnName;
 	}

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Auth\AuthManager;
 use Illuminate\Support\ServiceProvider;
 use Mitch\LaravelDoctrine\Cache;
 use Mitch\LaravelDoctrine\Configuration\DriverMapper;
+use Mitch\LaravelDoctrine\Configuration\LaravelNamingStrategy;
 use Mitch\LaravelDoctrine\Configuration\SqlMapper;
 use Mitch\LaravelDoctrine\Configuration\SqliteMapper;
 use Mitch\LaravelDoctrine\Configuration\OCIMapper;
@@ -108,6 +109,7 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             $metadata->setAutoGenerateProxyClasses($config['proxy']['auto_generate']);
             $metadata->setDefaultRepositoryClassName($config['repository']);
             $metadata->setSQLLogger($config['logger']);
+            $metadata->setNamingStrategy($app->make(LaravelNamingStrategy::class));
 
             if (isset($config['proxy']['namespace']))
                 $metadata->setProxyNamespace($config['proxy']['namespace']);

--- a/tests/Configuration/LaravelNamingStrategyTest.php
+++ b/tests/Configuration/LaravelNamingStrategyTest.php
@@ -1,0 +1,120 @@
+<?php namespace Tests\Configuration;
+
+use Illuminate\Support\Str;
+use Mitch\LaravelDoctrine\Configuration\LaravelNamingStrategy;
+
+class LaravelNamingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @type LaravelNamingStrategy
+     */
+    private $laravelNamingStrategy;
+
+    public function setUp()
+    {
+        // Mocking Str would be overkill
+        $this->laravelNamingStrategy = new LaravelNamingStrategy(new Str());
+    }
+
+	public function testProperTableName()
+    {
+        // Singular namespaced StudlyCase class
+        $className = 'Acme\\ClassName';
+
+        $tableName = $this->laravelNamingStrategy->classToTableName($className);
+
+        // Plural, snake_cased table name
+        $this->assertEquals('class_names', $tableName);
+    }
+
+    public function testProperColumnName()
+    {
+        // Columns derive from snakeCased fields
+        $field = 'createdAt';
+
+        $columnName = $this->laravelNamingStrategy->propertyToColumnName($field);
+
+        // And columns are just the snake_cased field
+        $this->assertEquals('created_at', $columnName);
+    }
+
+    public function testProperColumnNameWithClassName()
+    {
+        // Columns derive from snakeCased fields
+        $field = 'createdAt';
+
+        // Singular namespaced StudlyCase class
+        $className = 'Acme\\ClassName';
+
+        $columnName = $this->laravelNamingStrategy->propertyToColumnName($field, $className);
+
+        // Class name shouldn't affect how the column is called
+        $this->assertEquals('created_at', $columnName);
+    }
+
+    public function testEmbeddedColumnName()
+    {
+        // Laravel doesn't have embeddeds
+        $embeddedField = 'address';
+        $field = 'street1';
+
+        $columnName = $this->laravelNamingStrategy->embeddedFieldToColumnName($embeddedField, $field);
+
+        // So this is just like Doctrine's default naming strategy
+        $this->assertEquals('address_street1', $columnName);
+    }
+
+    public function testReferenceColumn()
+    {
+        // Laravel's convention is just 'id', like the default Doctrine
+        $columnName = $this->laravelNamingStrategy->referenceColumnName();
+
+        $this->assertEquals('id', $columnName);
+    }
+
+    public function testJoinColumnName()
+    {
+        // Given a User -> belongsTo -> Group
+        $field = 'group';
+
+        $columnName = $this->laravelNamingStrategy->joinColumnName($field);
+
+        // We expect to have a group_id in the users table
+        $this->assertEquals('group_id', $columnName);
+    }
+
+    public function testBelongsToManyJoinTable()
+    {
+        // Laravel doesn't do as Doctrine's default here
+        $sourceModel = 'Acme\\ClassName';
+
+        // We don't care about "source" or "target"
+        $targetModel = 'Acme\\AnotherClass';
+
+        // We should have it sorted by alphabetical order
+        $tableName = $this->laravelNamingStrategy->joinTableName($sourceModel, $targetModel);
+        $this->assertEquals('another_class_class_name', $tableName);
+
+        // Let's test swapping parameters, just in case...
+        $tableName = $this->laravelNamingStrategy->joinTableName($targetModel, $sourceModel);
+        $this->assertEquals('another_class_class_name', $tableName);
+    }
+
+    public function testJoinKeyColumnName()
+    {
+        // This case is similar to Doctrine's default as well
+        $className = 'Acme\\Foo';
+
+        // If no reference name is given, we use 'id'
+        $columnName = $this->laravelNamingStrategy->joinKeyColumnName($className);
+
+        // And expect singular_snake_id column
+        $this->assertEquals('foo_id', $columnName);
+
+        // Given a reference name
+        $columnName = $this->laravelNamingStrategy->joinKeyColumnName($className, 'reference');
+
+        // Same thing, but with that reference instead of 'id'
+        $this->assertEquals('foo_reference', $columnName);
+    }
+}


### PR DESCRIPTION
The laravel convention goes something like this:

Given a `User`, `Group` and `RealBusiness` schema:

`users`, `groups` and `real_businesses` for table names (pluralized snaked form.)
`users.id`, `groups.id` for ids (`id` as identifier convention.)
`user_group` for belongsToMany association tables (singular snaked concat of table names.)
`$realBusiness->user` for belongsTo associations (singular camel case of entity name.)
`$user->realBusinesses` for hasMany and belongsToMany associations (plural camel case of entity name.)

Using `Illuminate\Support\Str` To convert between singular / plural / camel / snake forms, so it should behave exactly as Laravel.
