### PR TITLE
Changes in composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "4.*|5.*",
+        "illuminate/support": "~4.2",
         "doctrine/orm": "2.5.*",
         "doctrine/migrations": "1.*"
     },
@@ -26,5 +26,6 @@
 	        "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
- Master branch points to Laravel ~4.2
- Added prefer-stable to only get the dev branches that we actually need (just doctrine/orm I believe).
