### PR TITLE
Pass class name not entity

### DIFF
--- a/src/EventListeners/SoftDeletableListener.php
+++ b/src/EventListeners/SoftDeletableListener.php
@@ -27,6 +27,6 @@ class SoftDeletableListener {
     }
 
     private function isSoftDeletable($entity) {
-        return array_key_exists('Mitch\LaravelDoctrine\Traits\SoftDeletes', class_uses_recursive($entity));
+        return array_key_exists('Mitch\LaravelDoctrine\Traits\SoftDeletes', class_uses_recursive(get_class($entity)));
     }
 }


### PR DESCRIPTION
`class_uses_recursive` expects a class name, not an instance. Blows up when using orphanRemoval for me.