### PR TITLE
Table prefix

### DIFF
--- a/src/Configuration/OCIMapper.php
+++ b/src/Configuration/OCIMapper.php
@@ -26,7 +26,8 @@ class OCIMapper implements Mapper
 			'dbname' => $configuration['database'],
 			'user' => $configuration['username'],
 			'password' => $configuration['password'],
-			'charset' => $configuration['charset']
+            'charset' => $configuration['charset'],
+            'prefix' => @$configuration['prefix'] ? $configuration['prefix'] : null
 		]);
 	}
 

--- a/src/Configuration/SqlMapper.php
+++ b/src/Configuration/SqlMapper.php
@@ -16,7 +16,8 @@ class SqlMapper implements Mapper
 			'dbname' => $configuration['database'],
 			'user' => $configuration['username'],
 			'password' => $configuration['password'],
-			'charset' => $configuration['charset']
+			'charset' => $configuration['charset'],
+        	'prefix' => @$configuration['prefix'] ? $configuration['prefix'] : null
 		];
 	}
 

--- a/src/Configuration/SqliteMapper.php
+++ b/src/Configuration/SqliteMapper.php
@@ -13,7 +13,8 @@ class SqliteMapper implements Mapper
 		$sqliteConfig = [
 			'driver' => 'pdo_sqlite',
 			'user' => @$configuration['username'],
-			'password' => @$configuration['password']
+            'password' => @$configuration['password'],
+            'prefix' => @$configuration['prefix'] ? $configuration['prefix'] : null
 		];
 		$this->databaseLocation($configuration, $sqliteConfig);
 		return $sqliteConfig;

--- a/src/EventListeners/TablePrefix.php
+++ b/src/EventListeners/TablePrefix.php
@@ -1,0 +1,48 @@
+<?php namespace Mitch\LaravelDoctrine\EventListeners;
+
+use \Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+class TablePrefix
+{
+    protected $prefix = '';
+
+    /**
+     * __construct
+     *
+     * @param string $prefix
+     */
+    public function __construct($prefix)
+    {
+        $this->prefix = (string) $prefix;
+    }
+
+    /**
+     * loadClassMetadata
+     *
+     * @link http://doctrine-orm.readthedocs.org/en/latest/cookbook/sql-table-prefixes.html
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+        $classMetadata->setTableName($this->prefix . $classMetadata->getTableName());
+
+        //if we use sequences, also prefix the sequence name
+        if($classMetadata->isIdGeneratorSequence()) {
+        
+            $sequenceDefinition = $classMetadata->sequenceGeneratorDefinition;
+            $sequenceDefinition['sequenceName'] = $this->prefix . $sequenceDefinition['sequenceName'];
+
+            $classMetadata->setSequenceGeneratorDefinition($sequenceDefinition);
+        }
+
+        foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
+            if ($mapping['type'] == \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY) {
+                $mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
+            }
+        }
+    }
+
+}
+

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -15,6 +15,7 @@ use Mitch\LaravelDoctrine\Configuration\SqlMapper;
 use Mitch\LaravelDoctrine\Configuration\SqliteMapper;
 use Mitch\LaravelDoctrine\Configuration\OCIMapper;
 use Mitch\LaravelDoctrine\EventListeners\SoftDeletableListener;
+use Mitch\LaravelDoctrine\EventListeners\TablePrefix;
 use Mitch\LaravelDoctrine\Filters\TrashedFilter;
 
 class LaravelDoctrineServiceProvider extends ServiceProvider
@@ -98,8 +99,18 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
                 $metadata->setProxyNamespace($config['proxy']['namespace']);
 
             $eventManager = new EventManager;
+
+            $connection_config = $this->mapLaravelToDoctrineConfig($app['config']);
+
+            //load prefix listener
+            if(isset($connection_config['prefix'])) {
+                $tablePrefix = new TablePrefix($connection_config['prefix']);
+                $eventManager->addEventListener(Events::loadClassMetadata, $tablePrefix);
+            }
+
             $eventManager->addEventListener(Events::onFlush, new SoftDeletableListener);
-            $entityManager = EntityManager::create($this->mapLaravelToDoctrineConfig($app['config']), $metadata, $eventManager);
+
+            $entityManager = EntityManager::create($connection_config, $metadata, $eventManager);
             $entityManager->getFilters()->enable('trashed');
             return $entityManager;
         });

--- a/tests/Configuration/OCIMapperTest.php
+++ b/tests/Configuration/OCIMapperTest.php
@@ -40,7 +40,8 @@ class OCIMapperTest extends \PHPUnit_Framework_TestCase
 			'dbname'   => $configuration['database'],
 			'user'     => $configuration['username'],
 			'password' => $configuration['password'],
-			'charset'  => $configuration['charset']
+            'charset'  => $configuration['charset'],
+            'prefix'   => $configuration['prefix']
 		];
 
 		$actual = $this->sqlMapper->map($configuration);

--- a/tests/Configuration/SqlMapperTest.php
+++ b/tests/Configuration/SqlMapperTest.php
@@ -36,9 +36,36 @@ class SqlMapperTest extends \PHPUnit_Framework_TestCase
 			'dbname'   => $configuration['database'],
 			'user'     => $configuration['username'],
 			'password' => $configuration['password'],
-			'charset'  => $configuration['charset']
+			'charset'  => $configuration['charset'],
+	        'prefix'   => $configuration['prefix']
 		];
 		$actual = $this->sqlMapper->map($configuration);
 		$this->assertEquals($expected, $actual);
 	}
+
+    public function testMappingWithoutPrefix() 
+    {
+		$configuration = [
+			'driver'   => 'mysql',
+			'host'     => 'localhost',
+			'database' => 'db',
+			'username' => 'somedude',
+			'password' => 'not safe',
+			'charset'  => 'whatevs'
+		];
+
+		$expected = [
+			'driver'   => 'pdo_mysql',
+			'host'     => $configuration['host'],
+			'dbname'   => $configuration['database'],
+			'user'     => $configuration['username'],
+			'password' => $configuration['password'],
+			'charset'  => $configuration['charset'],
+			'prefix'   => null
+		];
+
+		$actual = $this->sqlMapper->map($configuration);
+
+		$this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/Configuration/SqliteMapperTest.php
+++ b/tests/Configuration/SqliteMapperTest.php
@@ -35,7 +35,8 @@ class SqliteMapperTest extends \PHPUnit_Framework_TestCase
 			'driver'   => 'pdo_sqlite',
 			'path'     => $configuration['database'],
 			'user'     => $configuration['username'],
-            'password' => null
+            'password' => null,
+            'prefix'   => $configuration['prefix']
 		];
 		$actual = $this->sqlMapper->map($configuration);
 		$this->assertEquals($expected, $actual);

--- a/tests/EventListener/TablePrefixTest.php
+++ b/tests/EventListener/TablePrefixTest.php
@@ -1,0 +1,59 @@
+<?php namespace Test\EventListeners;
+
+use Mitch\LaravelDoctrine\EventListeners\TablePrefix;
+use \Doctrine\ORM\Mapping\ClassMetadata;
+use Mockery as m;
+
+class TablePrefixTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function setUp() {
+        $this->metadata = new ClassMetadata('\Foo');
+        $this->metadata->setTableName('foo');
+        
+        $this->objectManager = m::mock('Doctrine\Common\Persistence\ObjectManager');
+
+        $this->args = new \Doctrine\ORM\Event\LoadClassMetadataEventArgs($this->metadata, $this->objectManager);
+    }
+
+    /**
+     * Basic prefix test
+     */
+    public function testPrefixAdded() {
+
+        $tablePrefix = new TablePrefix('someprefix_');
+
+        //call the listener
+        $tablePrefix->loadClassMetadata($this->args);
+
+        $this->assertEquals('someprefix_foo', $this->metadata->getTableName());
+    }
+
+    /**
+     * Oracle specific, autoincrements are done using sequences
+     * this tests if the sequence also has the prefix - convinience
+     */
+    public function testPrefixAddedToSequence() {
+
+        $this->metadata->setSequenceGeneratorDefinition(array('sequenceName' => 'bar'));
+        $this->metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_SEQUENCE);
+
+        $tablePrefix = new TablePrefix('someprefix_');
+        $tablePrefix->loadClassMetadata($this->args);
+
+        $this->assertEquals('someprefix_foo', $this->metadata->getTableName());
+        $this->assertEquals(array('sequenceName' => 'someprefix_bar'), $this->metadata->sequenceGeneratorDefinition);
+
+    }
+
+    public function testManyToManyHasPrefix() {
+
+        $this->metadata->mapManyToMany(array('fieldName' => 'fooBar', 'targetEntity' => 'bar'));
+
+        $tablePrefix = new TablePrefix('someprefix_');
+        $tablePrefix->loadClassMetadata($this->args);
+
+        $this->assertEquals('someprefix_foo', $this->metadata->getTableName());
+        $this->assertEquals('someprefix_foo_bar', $this->metadata->associationMappings['fooBar']['joinTable']['name']);
+    }
+}


### PR DESCRIPTION
Hi,

Thought this could be usefull as it's in the laravel default database configuration! 

This is based on [Doctrine table prefix cookbook](http://doctrine-orm.readthedocs.org/en/latest/cookbook/sql-table-prefixes.html) with a small improvement on Sequences. It adds the prefix to the created sequence to match the table name.

I've tested this manually, but if you have any idea on how to test this without having to create mappings let me know and I'll add it!   