### PR TITLE
Patch L5 auth

### DIFF
--- a/src/DoctrineUserProvider.php
+++ b/src/DoctrineUserProvider.php
@@ -53,6 +53,7 @@ class DoctrineUserProvider implements UserProvider
     public function retrieveByToken($identifier, $token)
     {
         $entity = $this->getEntity();
+
         return $this->getRepository()->findOneBy([
             $entity->getKeyName() => $identifier,
             $entity->getRememberTokenName() => $token
@@ -82,9 +83,11 @@ class DoctrineUserProvider implements UserProvider
     public function retrieveByCredentials(array $credentials)
     {
         $criteria = [];
-        foreach ($credentials as $key => $value)
-            if ( ! str_contains($key, 'password'))
+        foreach ($credentials as $key => $value) {
+            if ( ! str_contains($key, 'password')) {
                 $criteria[$key] = $value;
+            }
+        }
 
         return $this->getRepository()->findOneBy($criteria);
     }

--- a/src/DoctrineUserProvider.php
+++ b/src/DoctrineUserProvider.php
@@ -2,11 +2,11 @@
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
-use Illuminate\Auth\UserProviderInterface;
+use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Hashing\Hasher;
 
-class DoctrineUserProvider implements UserProviderInterface
+class DoctrineUserProvider implements UserProvider
 {
     /**
      * @var Hasher

--- a/src/Traits/Authentication.php
+++ b/src/Traits/Authentication.php
@@ -1,5 +1,6 @@
 <?php namespace Mitch\LaravelDoctrine\Traits;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping AS ORM;
 
 trait Authentication {
@@ -27,7 +28,9 @@ trait Authentication {
      * @return mixed
      */
     public function getAuthIdentifier() {
-        return method_exists($this, 'getKeyName') ? $this->getKeyName() : 'id';
+        $entityManager = app('Doctrine\ORM\EntityManager');
+
+        return $this->{$entityManager->getClassMetadata(get_class($this))->getSingleIdentifierFieldName()};
     }
 
     /**

--- a/src/Traits/Authentication.php
+++ b/src/Traits/Authentication.php
@@ -63,6 +63,6 @@ trait Authentication {
      * @return string
      */
     public function getRememberTokenName() {
-        return 'remember_token';
+        return 'rememberToken';
     }
 } 


### PR DESCRIPTION
Hello!

These commits fix the authentication for L5.
I'm not sure about the `getAuthIdentifier` method. It is working, but maybe there's a better way of doing this and not actually call `app()`?