### PR TITLE
TrashedFilter: Stop get_class call when FQCN is passed

### DIFF
--- a/src/Filters/TrashedFilter.php
+++ b/src/Filters/TrashedFilter.php
@@ -10,6 +10,6 @@ class TrashedFilter extends SQLFilter {
     }
 
     private function isSoftDeletable($entity) {
-        return array_key_exists('Mitch\LaravelDoctrine\Traits\SoftDeletes', class_uses_recursive(get_class($entity)));
+        return array_key_exists('Mitch\LaravelDoctrine\Traits\SoftDeletes', class_uses_recursive($entity));
     }
 }


### PR DESCRIPTION
When checking if an entity is soft-deletable, a FQCN is passed - resulting in get_class being called on a string.

Fixes:
ErrorException: get_class() expects parameter 1 to be object, string given