### PR TITLE
DoctrinePresenceVerifier->getCount() returning null

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -75,7 +75,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
 			$query->setParameter($key + 2, $extraValue);
 		}
 
-		return $query->count();
+		return $query->getSingleScalarResult();
 	}
 
 	/**
@@ -87,6 +87,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
 	private function createQueryFrom(array $queryParts = [])
 	{
 		$rsm = new ResultSetMapping();
+		$rsm->addScalarResult('COUNT(*)', 'c');
 
 		return $this->entityManager->createNativeQuery(implode(' ', $queryParts), $rsm);
 	}


### PR DESCRIPTION
When using the unique validation rule `DoctrinePresenceVerifier->getCount()` was returning null because the scalar result wasn't been added to the result set.

Also noticed that an error would occur in `getMultiCount()` as the `count()` method isn't available on `ResultSetMapping`.