### PR TITLE
Persist the entity if it was already deleted

### DIFF
--- a/src/EventListeners/SoftDeletableListener.php
+++ b/src/EventListeners/SoftDeletableListener.php
@@ -12,8 +12,10 @@ class SoftDeletableListener {
             if ($this->isSoftDeletable($entity)) {
                 $metadata = $entityManager->getClassMetadata(get_class($entity));
                 $oldDeletedAt = $metadata->getFieldValue($entity, 'deletedAt');
-                if ($oldDeletedAt instanceof DateTime)
+                if ($oldDeletedAt instanceof DateTime) {
+                    $entityManager->persist($entity);
                     continue;
+                }
                 $now = new DateTime;
                 $metadata->setFieldValue($entity, 'deletedAt', $now);
                 $entityManager->persist($entity);


### PR DESCRIPTION
I don't know if this is a bug or a feature, but it seems that entities that are already "soft deleted" should still be persisted if it is tried to be deleted.