### PR TITLE
Added ability to add event listeners via config file

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -28,6 +28,10 @@ return [
         ]
     ],
 
+    'event_listeners' => [
+        Mitch\LaravelDoctrine\EventListeners\SoftDeletableListener::class => Doctrine\ORM\Events::onFlush
+    ],
+
     'repository' => 'Doctrine\ORM\EntityRepository',
 
     'repositoryFactory' => null,

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -28,8 +28,13 @@ return [
         ]
     ],
 
-    'event_listeners' => [
-        Mitch\LaravelDoctrine\EventListeners\SoftDeletableListener::class => Doctrine\ORM\Events::onFlush
+    'events'=> [
+        'listeners' => [
+            Mitch\LaravelDoctrine\EventListeners\SoftDeletableListener::class => Doctrine\ORM\Events::onFlush
+        ],
+        'subscribers' => [
+            //
+        ]
     ],
 
     'repository' => 'Doctrine\ORM\EntityRepository',

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -15,7 +15,6 @@ use Mitch\LaravelDoctrine\Configuration\LaravelNamingStrategy;
 use Mitch\LaravelDoctrine\Configuration\SqlMapper;
 use Mitch\LaravelDoctrine\Configuration\SqliteMapper;
 use Mitch\LaravelDoctrine\Configuration\OCIMapper;
-use Mitch\LaravelDoctrine\EventListeners\SoftDeletableListener;
 use Mitch\LaravelDoctrine\EventListeners\TablePrefix;
 use Mitch\LaravelDoctrine\Filters\TrashedFilter;
 use Mitch\LaravelDoctrine\Validation\DoctrinePresenceVerifier;
@@ -124,7 +123,9 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
                 $eventManager->addEventListener(Events::loadClassMetadata, $tablePrefix);
             }
 
-            $eventManager->addEventListener(Events::onFlush, new SoftDeletableListener);
+            foreach($config['event_listeners'] as $listener => $event) {
+                $eventManager->addEventListener($event, new $listener);
+            }
 
             $entityManager = EntityManager::create($connection_config, $metadata, $eventManager);
             $entityManager->getFilters()->enable('trashed');

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -123,8 +123,12 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
                 $eventManager->addEventListener(Events::loadClassMetadata, $tablePrefix);
             }
 
-            foreach($config['event_listeners'] as $listener => $event) {
+            foreach($config['events']['listeners'] as $listener => $event) {
                 $eventManager->addEventListener($event, new $listener);
+            }
+
+            foreach($config['events']['subscribers'] as $subscriber) {
+                $eventManager->addEventSubscriber(new $subscriber);
             }
 
             $entityManager = EntityManager::create($connection_config, $metadata, $eventManager);


### PR DESCRIPTION
I needed to add more event listeners to the entity manager, so I just added a new config item. I've left the TablePrefix listener as is and didn't move it to the event_listeners array.
