### PR TITLE
Fixed issue with no option mapping

### DIFF
--- a/src/Configuration/SqlMapper.php
+++ b/src/Configuration/SqlMapper.php
@@ -9,7 +9,8 @@ class SqlMapper implements Mapper {
             'dbname' => $configuration['database'],
             'user' => $configuration['username'],
             'password' => $configuration['password'],
-            'charset' => $configuration['charset']
+            'charset' => $configuration['charset'],
+            'driverOptions' => $configuration['options']
         ];
     }
 


### PR DESCRIPTION
Hi,
I've got the issue which took me a long time to track down. I had problems with UTF-8 chars. In Laravel config I set the options parameter:

```
 'options'   => [
                PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8; SET CHARACTER SET utf8"
            ],
```

however without effect. 
Finally I noticed that the options from Laravel are not used by Doctrine.
