### PR TITLE
DoctrineUserProvider fixed UserProvider contract usage

### DIFF
--- a/src/DoctrineUserProvider.php
+++ b/src/DoctrineUserProvider.php
@@ -2,11 +2,11 @@
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
-use Illuminate\Auth\UserProviderInterface;
+use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Hashing\Hasher;
 
-class DoctrineUserProvider implements UserProviderInterface
+class DoctrineUserProvider implements UserProvider
 {
     /**
      * @var Hasher


### PR DESCRIPTION
In laravel 5.1 UserProviderInterface has been removed so I changed it to the correct one from Illuminate\Contracts\Auth\UserProvider.