### PR TITLE
Doctrine proxy directory

### DIFF
--- a/src/Console/GenerateProxiesCommand.php
+++ b/src/Console/GenerateProxiesCommand.php
@@ -41,7 +41,7 @@ class GenerateProxiesCommand extends Command
             $this->error('No metadata found to generate any entities.');
             exit;
         }
-        $directory = $this->laravel['config']['doctrine::doctrine.proxy.directory'];
+        $directory = $this->laravel['config']['doctrine.proxy.directory'];
         if ( ! $directory) {
             $this->error('The proxy directory has not been set.');
             exit;


### PR DESCRIPTION
doctrine::doctrine.proxy.directory is wrong. It doesn't work if I put the path in my doctrine config file. When I deleted doctrine::, it did work. It also makes more sense. Please check this, as this might be a fix