### PR TITLE
Introduce `cache-key-namespace` configuration

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -16,6 +16,11 @@ return [
     // Available: null, apc, xcache, redis, memcache
     'cache_provider' => null,
 
+    // A string that will act as a prefix for cached values' keys.
+    // When left as `null`, this will be internally defaulted to:
+    // "dc2_" . md5($proxyDir) . "_", see: Doctrine\ORM\Tools\Setup
+    'cache_key_namespace' => null,
+
     'cache' => [
         'redis' => [
             'host'     => '127.0.0.1',

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\EventManager;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Support\ServiceProvider;
@@ -98,10 +99,15 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
     {
         $this->app->singleton(EntityManager::class, function ($app) {
             $config = $app['config']['doctrine::doctrine'];
+
+            /** @var CacheProvider|null $cacheProvider */
+            $cacheProvider = $app['Mitch\LaravelDoctrine\CacheManager']->getCache($config['cache_provider']);
+
             $metadata = Setup::createAnnotationMetadataConfiguration(
                 $config['metadata'],
                 $app['config']['app.debug'],
                 $config['proxy']['directory'],
+                $cacheProvider,
                 $app[CacheManager::class]->getCache($config['cache_provider']),
                 $config['simple_annotations']
             );
@@ -122,6 +128,17 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             if(isset($connection_config['prefix'])) {
                 $tablePrefix = new TablePrefix($connection_config['prefix']);
                 $eventManager->addEventListener(Events::loadClassMetadata, $tablePrefix);
+            }
+
+            /*
+             * We need to do that here, because the namespace is defaulted in
+             * Setup::createAnnotationMetadataConfiguration
+             */
+            if (
+                isset($config['cache_key_namespace'])
+                && $cacheProvider
+            ) {
+                $cacheProvider->setNamespace($config['cache_key_namespace']);
             }
 
             $eventManager->addEventListener(Events::onFlush, new SoftDeletableListener);


### PR DESCRIPTION
Add an ability to configure the cache's keys namespace. This is useful if you need extra control over handling key names collisions in your Cache solution.