### PR TITLE
Register available cache providers in the config file.

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -20,7 +20,7 @@ return [
     // and then put its name here.
     'cache_provider' => null,
 
-    'cache_providers' => [
+    'available_cache_providers' => [
 //        new Cache\ApcProvider,
 //        new Cache\MemcacheProvider,
 //        new Cache\RedisProvider,

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,5 +1,8 @@
 <?php
 
+use Mitch\LaravelDoctrine\Cache;
+
+
 return [
     'simple_annotations' => false,
 
@@ -13,8 +16,17 @@ return [
         'namespace'     => null
     ],
 
-    // Available: null, apc, xcache, redis, memcache
+    // Uncomment the cache_provider you want to use in 'cache_providers' below,
+    // and then put its name here.
     'cache_provider' => null,
+
+    'cache_providers' => [
+//        new Cache\ApcProvider,
+//        new Cache\MemcacheProvider,
+//        new Cache\RedisProvider,
+//        new Cache\XcacheProvider,
+//        new Cache\NullProvider,
+    ],
 
     'cache' => [
         'redis' => [

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -84,12 +84,17 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
     public function registerCacheManager()
     {
         $this->app->bind(CacheManager::class, function ($app) {
-            $manager = new CacheManager($app['config']['doctrine::doctrine.cache']);
-            $manager->add(new Cache\ApcProvider);
-            $manager->add(new Cache\MemcacheProvider);
-            $manager->add(new Cache\RedisProvider);
-            $manager->add(new Cache\XcacheProvider);
-            $manager->add(new Cache\NullProvider);
+            $config = $app['config']['doctrine::doctrine'];
+            $manager = new CacheManager($config['cache']);
+
+            foreach ($config['cache_providers'] as $cacheProvider) {
+                if (! ($cacheProvider instanceof Cache\Provider)) {
+                    throw new \RuntimeException(sprintf('Expected implementation of `Cache\Provider` interface, but got: `%s`', get_class($cacheProvider)));
+                }
+
+                $manager->add($cacheProvider);
+            }
+
             return $manager;
         });
     }

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -87,7 +87,7 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             $config = $app['config']['doctrine::doctrine'];
             $manager = new CacheManager($config['cache']);
 
-            foreach ($config['cache_providers'] as $cacheProvider) {
+            foreach ($config['available_cache_providers'] as $cacheProvider) {
                 if (! ($cacheProvider instanceof Cache\Provider)) {
                     throw new \RuntimeException(sprintf('Expected implementation of `Cache\Provider` interface, but got: `%s`', get_class($cacheProvider)));
                 }


### PR DESCRIPTION
This is needed so registering new cache providers doesn't involve hacking the project's code. Also, the default cache providers are not even `new'd` when the end user doesn't want to use doctrine's cache, which is a tiny performance boost