### PR TITLE
Add a laravel command that allows devs to run doctrine's cli commands

### DIFF
--- a/src/Console/DoctrineCliCommand.php
+++ b/src/Console/DoctrineCliCommand.php
@@ -1,0 +1,59 @@
+<?php  namespace Mitch\LaravelDoctrine\Console;
+
+use Doctrine\ORM\Tools\Console\ConsoleRunner;
+use Illuminate\Console\Command;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+
+
+class DoctrineCliCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:cli';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run native doctrine command.';
+
+    /**
+     * The Entity Manager
+     *
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $entityManager;
+
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+
+        $this->addArgument(
+            'doctrineCliCommand',
+            InputArgument::REQUIRED,
+            'Doctrine cli command.'
+        );
+    }
+
+    public function fire()
+    {
+        $consoleRunner = new ConsoleRunner();
+        $cliApplication = $consoleRunner->createApplication(
+            $consoleRunner->createHelperSet($this->entityManager)
+        );
+
+        $doctrineCliInput = new ArrayInput(array(
+            'command' => $this->input->getArgument('doctrineCliCommand'),
+        ));
+
+        $cliApplication->run($doctrineCliInput, $this->output);
+    }
+} 

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -50,7 +50,8 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             'Mitch\LaravelDoctrine\Console\GenerateProxiesCommand',
             'Mitch\LaravelDoctrine\Console\SchemaCreateCommand',
             'Mitch\LaravelDoctrine\Console\SchemaUpdateCommand',
-            'Mitch\LaravelDoctrine\Console\SchemaDropCommand'
+            'Mitch\LaravelDoctrine\Console\SchemaDropCommand',
+            'Mitch\LaravelDoctrine\Console\DoctrineCliCommand',
         ]);
     }
 


### PR DESCRIPTION
This allows devs to run Doctrine's commands: [link](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/tools.html#command-overview) using laravel's `artisan`. This doesn't support passing `--` options. But at least it allows to clear the cache.