### PR TITLE
Add an option to create separate cache for Doctrine's query results

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -21,6 +21,13 @@ return [
     // "dc2_" . md5($proxyDir) . "_", see: Doctrine\ORM\Tools\Setup
     'cache_key_namespace' => null,
 
+    // When set to `null`, then the doctrine's query result cache will be the same
+    // as the metadata and query caches. If you need to be able to flush query result
+    // cache without touching the metadata and query caches, then set the following
+    // namespace to something different from the value in the `cache_key_namespace`
+    // config.
+    'result_cache_key_namespace' => null,
+
     'cache' => [
         'redis' => [
             'host'     => '127.0.0.1',

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -16,6 +16,11 @@ return [
     // Available: null, apc, xcache, redis, memcache
     'cache_provider' => null,
 
+    // A string that will act as a prefix for cached values' keys.
+    // When left as `null`, this will be internally defaulted to:
+    // "dc2_" . md5($proxyDir) . "_", see: Doctrine\ORM\Tools\Setup
+    'cache_key_namespace' => null,
+
     'cache' => [
         'redis' => [
             'host'     => '127.0.0.1',

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -1,5 +1,6 @@
-<?php namespace Mitch\LaravelDoctrine; 
+<?php namespace Mitch\LaravelDoctrine;
 
+use Doctrine\Common\Cache\CacheProvider;
 use Mitch\LaravelDoctrine\Cache\Provider;
 
 class CacheManager
@@ -11,6 +12,10 @@ class CacheManager
         $this->config = $config;
     }
 
+    /**
+     * @param string $type
+     * @return CacheProvider|null
+     */
     public function getCache($type)
     {
         foreach ($this->providers as $provider)

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -100,8 +100,10 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
         $this->app->singleton(EntityManager::class, function ($app) {
             $config = $app['config']['doctrine::doctrine'];
 
-            /** @var CacheProvider|null $cacheProvider */
-            $cacheProvider = $app['Mitch\LaravelDoctrine\CacheManager']->getCache($config['cache_provider']);
+            /** @var CacheManager $cacheManager */
+            $cacheManager = $app['Mitch\LaravelDoctrine\CacheManager'];
+
+            $cacheProvider = $cacheManager->getCache($config['cache_provider']);
 
             $metadata = Setup::createAnnotationMetadataConfiguration(
                 $config['metadata'],
@@ -138,6 +140,16 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
                 && $cacheProvider
             ) {
                 $cacheProvider->setNamespace($config['cache_key_namespace']);
+            }
+
+            if (
+                isset($config['result_cache_key_namespace'])
+                && isset($config['cache_provider'])
+            ) {
+                $resultCacheProvider = $cacheManager->getCache($config['cache_provider']);
+                $resultCacheProvider->setNamespace($config['result_cache_key_namespace']);
+
+                $metadata->setResultCacheImpl($cacheManager->getCache($config['cache_provider']));
             }
 
             $eventManager->addEventListener(Events::onFlush, new SoftDeletableListener);

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -108,7 +108,6 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
                 $app['config']['app.debug'],
                 $config['proxy']['directory'],
                 $cacheProvider,
-                $app[CacheManager::class]->getCache($config['cache_provider']),
                 $config['simple_annotations']
             );
             $metadata->addFilter('trashed', TrashedFilter::class);

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\EventManager;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Support\ServiceProvider;
@@ -98,10 +99,15 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
     {
         $this->app->singleton(EntityManager::class, function ($app) {
             $config = $app['config']['doctrine::doctrine'];
+
+            /** @var CacheProvider|null $cacheProvider */
+            $cacheProvider = $app['Mitch\LaravelDoctrine\CacheManager']->getCache($config['cache_provider']);
+
             $metadata = Setup::createAnnotationMetadataConfiguration(
                 $config['metadata'],
                 $app['config']['app.debug'],
                 $config['proxy']['directory'],
+                $cacheProvider,
                 $app[CacheManager::class]->getCache($config['cache_provider']),
                 $config['simple_annotations']
             );
@@ -122,6 +128,17 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             if(isset($connection_config['prefix'])) {
                 $tablePrefix = new TablePrefix($connection_config['prefix']);
                 $eventManager->addEventListener(Events::loadClassMetadata, $tablePrefix);
+            }
+
+            /*
+             * We need to do that here, because the namespace is defaulted in
+             * Setup::createAnnotationMetadataConfiguration
+             */
+            if (
+                isset($config['cache_key_namespace'])
+                && $cacheProvider
+            ) {
+                $cacheProvider->setNamespace($config['cache_key_namespace']);
             }
 
             $eventManager->addEventListener(Events::onFlush, new SoftDeletableListener);


### PR DESCRIPTION
This is useful, if devs want to be able to clear Doctrine's result cache independently from Doctrine's metadata and query caches. 

This PR requires [this](https://github.com/mitchellvanw/laravel-doctrine/pull/138) PR.