### PR TITLE
Update readme to point to laravel-doctrine/orm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Doctrine 2 for Laravel
+# Doctrine 2 for Laravel (NO LONGER MAINTAINED! Try [laravel-doctrine/orm](https://github.com/laravel-doctrine/orm) instead!)
 
 [![Latest Stable Version](https://poser.pugx.org/mitchellvanw/laravel-doctrine/version.png)](https://packagist.org/packages/mitchellvanw/laravel-doctrine)
 [![License](https://poser.pugx.org/mitchellvanw/laravel-doctrine/license.png)](https://packagist.org/packages/mitchellvanw/laravel-doctrine)


### PR DESCRIPTION
Hi @mitchellvanw and @kirkbushell ,

This project seems to be abandoned. Would you consider pointing to [our package](https://github.com/laravel-doctrine/orm) in your readme? We aim to provide the same features (and more) to developers looking for a solution for doctrine integration with Laravel and would be happy to support the userbase for this package going forward. You can find out more about our team/package at [laraveldoctrine.org](http://www.laraveldoctrine.org/docs/1.0/orm).

Migration from this package to ours should be easy since they follow similar lines of thought **plus** I wrote a [configuration converter](http://www.laraveldoctrine.org/docs/1.0/orm/upgrade) to generate new configs for our package from configs from this one.
