### PR TITLE
Fix SoftDeletes for null values in the DB (not deleted entries).

### DIFF
--- a/src/Traits/SoftDeletes.php
+++ b/src/Traits/SoftDeletes.php
@@ -23,6 +23,7 @@ trait SoftDeletes
 
     public function isDeleted()
     {
-        return new DateTime > $this->deletedAt;
+        if($this->deletedAt == null) return false;
+         else return new DateTime > $this->deletedAt;
     }
 }


### PR DESCRIPTION
Function isDeleted for SoftDeletes returns true even if value of isDeleted is set to null. This fix changes the return value to false in this case.